### PR TITLE
ci: add code coverage gate with baseline thresholds

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -21,6 +21,62 @@ jobs:
       pages: write
       id-token: write
 
+  coverage:
+    # Coverage thresholds live in vite.config.js under
+    # `test.coverage.thresholds`. The `--coverage` flag fails the
+    # run when any of statements / branches / functions / lines
+    # falls below its configured floor. `tee` keeps the full
+    # output for the step-summary block below.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci || npm i
+
+      - name: Run coverage
+        run: |
+          set -o pipefail
+          npm run test:coverage 2>&1 | tee /tmp/cov.txt
+
+      # Upload the full HTML / json-summary reports as an artifact
+      # so reviewers can drill into per-file line-level coverage
+      # when the run-page summary's totals aren't enough. `always()`
+      # so the artifact still uploads when thresholds fail — that's
+      # exactly when humans want the numbers.
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: coverage/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      # Surface the coverage summary on the run page. `always()` so
+      # it posts even when thresholds fail.
+      - name: Post coverage to step summary
+        if: always()
+        run: |
+          {
+            echo "## Test coverage — \`$GITHUB_SHA\`"
+            echo
+            echo '```text'
+            if [ -f /tmp/cov.txt ]; then
+              awk '/^=+ Coverage summary =+$/,/^=+$/' /tmp/cov.txt \
+                || tail -n 8 /tmp/cov.txt
+            else
+              echo "(coverage did not run)"
+            fi
+            echo '```'
+            echo
+            echo "Thresholds (from \`vite.config.js → test.coverage.thresholds\`):"
+            echo "lines ≥ 19, statements ≥ 18, branches ≥ 19, functions ≥ 13."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   pr-artifacts:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@vitejs/plugin-react": "^5.2.0",
+        "@vitest/coverage-v8": "^4.1.5",
         "archiver": "^7.0.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
@@ -319,6 +320,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@devicefarmer/adbkit": {
@@ -2432,6 +2443,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -2917,6 +2959,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -6013,6 +6074,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6421,6 +6528,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/make-error": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/coverage-v8": "^4.1.5",
     "archiver": "^7.0.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
@@ -26,6 +27,7 @@
     "package": "npm run build && npm run bundle",
     "package-syle": "VITE_DEFAULT_URL_PORTER_SYNC_SERVER_URL=https://synle.github.io/fav/url-porter.json npm run package",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src/",
     "format": "prettier --write --print-width 140 --ignore-unknown --no-error-on-unmatched-pattern --cache '**/*.{js,jsx,ts,tsx,mjs,cjs,json,html,css,scss,less,md,yml,yaml,graphql,vue,xml}'",
     "validate": "npm test && npm run lint && npm run build && npm run format"

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,27 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const isDev = process.argv.includes("--watch");
 
 export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary", "json-summary", "html"],
+      reportsDirectory: "coverage",
+      include: ["src/**/*.{js,jsx,ts,tsx}"],
+      exclude: ["src/**/*.{test,spec}.{js,jsx,ts,tsx}", "src/**/*.d.ts", "scripts/**"],
+      // Baseline captured at v1.84.0 against the current 8-file
+      // test suite (Statements 19.97 / Branches 20.33 /
+      // Functions 14.71 / Lines 20.26). CI floor is the integer
+      // baseline minus 1pt as a safety margin against coincidental
+      // flakes — a real regression beyond that fails the build.
+      // Raise these as coverage improves; never lower them.
+      thresholds: {
+        lines: 19,
+        statements: 18,
+        branches: 19,
+        functions: 13,
+      },
+    },
+  },
   build: {
     outDir: "dist",
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

- Wire Vitest v8 coverage into `build-main.yml` as a new `coverage` job (runs on push to main + pull_request).
- Pin thresholds to the current baseline minus a 1pt safety margin so future regressions fail the build, while leaving headroom for flakes.
- Upload the `coverage/` directory as a `coverage-reports` artifact (30 day retention) and post the summary block to the run page — both `if: always()` so they surface even when thresholds fail.

## Baseline vs. CI floor

Measured locally against the 8 test files (170 tests) at v1.84.0:

| Metric     | Baseline | CI floor |
| ---------- | -------: | -------: |
| Statements |  19.97 % |     18 % |
| Branches   |  20.33 % |     19 % |
| Functions  |  14.71 % |     13 % |
| Lines      |  20.26 % |     19 % |

Floor = `floor(baseline) - 1`. Raise as coverage improves; never lower.

## Test plan

- [x] `npm run test:coverage` passes locally (170/170 tests, exit 0, thresholds satisfied)
- [x] `npm test` and `npm run lint` still clean
- [ ] CI `coverage` job is green on this PR
- [ ] Run-page step summary shows the coverage block
- [ ] `coverage-reports` artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)